### PR TITLE
Version 0.3.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,21 @@
 
 --------
 
+## Version 0.3.0
+
+### Minor updates - 0.3.0
+
+- (Main) Adding the option '-g', allowing pod/container review from a specific cgroup as requested in RFE #5
+
+### Release updates - 0.3.0
+
+- (Help) Reduce space when displaying the current version
+- (Main) Enforcing the number of parameters.
+- (Main) Redirecting some command error message to the output set in variable ${STD_ERR}
+- (Various) Rewriting few messages and comments.
+
+--------
+
 ## Version 0.2.1
 
 ### Minor updates - 0.2.1
@@ -20,7 +35,7 @@
 
 ### Release updates - 0.2.1
 
-- Update 'awk' filter based on different crictl_ps_-a output when retreiving the POD list from a container name. 
+- Update 'awk' filter based on different crictl_ps_-a output when retreiving the POD list from a container name.
 - Add the version number in the help message
 
 --------

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you provide the full PODID, the script will trunk it to 13 characters.
 using the `-h` option will display the help and provide the list of the available options, and the version of the script.
 
 ```text
-usage: sos4ocp.sh [-s <SOSREPORT_PATH>] [-n <PODNAME>|-i <PODID>|-c <CONTAINER_NAME>] [-h]
+usage: sos4ocp.sh [-s <SOSREPORT_PATH>] [-n <PODNAME>|-i <PODID>|-c <CONTAINER_NAME>|-g <CGROUP>] [-h]
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Options | Description                                                     | [Default]                                                                     |
 |---------|-----------------------------------------------------------------|-------------------------------------------------------------------------------|
@@ -64,11 +64,12 @@ usage: sos4ocp.sh [-s <SOSREPORT_PATH>] [-n <PODNAME>|-i <PODID>|-c <CONTAINER_N
 |      -n | Name of the POD                                                 | null (if POD/CONTAINER options are missing, provide choice between all PODs)  |
 |      -i | UID of the POD                                                  | null (if POD/CONTAINER options are missing, provide choice between all PODs)  |
 |      -c | Name of a CONTAINER                                             | null (if POD/CONTAINER options are missing, provide choice between all PODs)  |
+|      -g | Specific cgroup                                                 | null                                                                          |
 |---------|-----------------------------------------------------------------|-------------------------------------------------------------------------------|
 |         | Additional Options:                                             |                                                                               |
 |---------|-----------------------------------------------------------------|-------------------------------------------------------------------------------|
 |      -h | display this help and check for updated version                 |                                                                               |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 
-Current Version:	 X.X.X
+Current Version: X.X.X
 ```


### PR DESCRIPTION
- (Main) Adding the option '-g', allowing pod/container review from a specific cgroup as requested in RFE #5
- (Help) Reduce space when displaying the current version
- (Main) Enforcing the number of parameters.
- (Main) Redirecting some command error message to the output set in variable /dev/null
- (Various) Rewriting few messages and comments.