### PR TITLE
Version 0.4.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,19 @@
 
 --------
 
+## Version 0.4.1
+
+### Minor updates - 0.4.1
+
+- None
+
+### Release updates - 0.4.1
+
+- (README) Fix a typo
+- (Main) Ensure the inspect files are 'JSON DATA' when searching for the cgroup, avoiding filtering failure (Issue #9 point 2.)
+
+--------
+
 ## Version 0.4.0
 
 ### Minor updates - 0.4.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sos4ocp
 
-This bash script will display PDO and containers details for a specific POD within a SOSREPORT
+This bash script will display POD and containers details for a specific POD within a SOSREPORT
 
 ## Installation and updates
 

--- a/sos4ocp.sh
+++ b/sos4ocp.sh
@@ -233,7 +233,7 @@ else
         echo -e "List of PODs including the container: ${CONTAINERNAME}\n"
         ;;
       "CGROUP")
-        POD_IDS_LIST=($(jq -r --arg cgroup "${CGROUP}" '. | select(.info.runtimeSpec.linux.cgroupsPath | test($cgroup)) | "\(.status.id[0:13]) "' ${CRIO_PATH}/pods/crictl_inspectp_*))
+        POD_IDS_LIST=($(jq -r --arg cgroup "${CGROUP}" '.? | select(.info.runtimeSpec.linux.cgroupsPath | test($cgroup)) | "\(.status.id[0:13]) "' $(file ${CRIO_PATH}/pods/crictl_inspectp_* | grep -E "JSON data" | cut -d':' -f1)))
         echo -e "List of PODs including the cgroup: ${CGROUP}\n"
         ;;
       "NAMESPACE")


### PR DESCRIPTION
- (README) Fix a typo
- (Main) Ensure the inspect files are 'JSON DATA' when searching for the cgroup, avoiding filtering failure (Issue #9 point 2.)