### PR TITLE
Version 1.0.4

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@
 ### Release updates - 1.0.4
 
 - (Main) Adding the option '-I', allowing pod/container review from a specific 'container ID' (truncated to 13 characters)
+- (Main) fixing the function 'fct_container_statistic' to correctly match the crictl_stats output.
 
 --------
 

--- a/sos4ocp.sh
+++ b/sos4ocp.sh
@@ -184,7 +184,13 @@ fi
 
 #Retrieve container statistic
 fct_container_statistic(){
-  awk -v container_id=$1 'BEGIN{if($2 == "NAME"){Include_Name=true}}{if($1 == container_id){if(Include_Name==true){stats=$3"|"$4"|"$5"|"$6}else{stats=$2"|"$3"|"$4"|"$5}}}END{if (stats != ""){printf stats}else{printf "-|-|-|-"}}' ${CRIO_PATH}/crictl_stats
+  #Check if the container name is included in the crictl_stats data
+  if [[ $(awk 'BEGIN{namepresence="false"}{if($2 == "NAME"){namepresence="true"}}END{print namepresence}' ${CRIO_PATH}/crictl_stats) == "true" ]]
+  then
+    awk -v container_id=$1 '{if($1 == container_id){stats=$3"|"$4"|"$5"|"$6}}END{if (stats != ""){printf stats}else{printf "-|-|-|-"}}' ${CRIO_PATH}/crictl_stats
+  else
+    awk -v container_id=$1 '{if($1 == container_id){stats=$2"|"$3"|"$4"|"$5}}END{if (stats != ""){printf stats}else{printf "-|-|-|-"}}' ${CRIO_PATH}/crictl_stats
+  fi
 }
 ##### Main
 


### PR DESCRIPTION
- (Main) Adding the option '-I', allowing pod/container review from a specific 'container ID' (truncated to 13 characters)
- (Main) fixing the function 'fct_container_statistic' to correctly match the crictl_stats output.