### PR TITLE
Version 1.4.0

### DIFF
--- a/sos4ocp.sh
+++ b/sos4ocp.sh
@@ -370,7 +370,7 @@ fct_image_size_overlay()
       echo -e " |-> ${cyantext}Containers${resetcolor} ($(echo ${IMAGE_JSON} | jq -r --arg image ${image} '.[] | select(.status.id == $image) | .containers | length'))"
       if [[ $(echo ${IMAGE_JSON} | jq -r --arg image ${image} '.[] | select(.status.id == $image) | .containers | length') != 0 ]]
       then
-        echo ${IMAGE_JSON} | jq -r --arg image ${image} '" \\    Namespace#POD Name#Container Name#Container ID#Container Layer ID#State",(.[] | select(.status.id == $image) | .containers[]? | "  |-> \(.namespace)#\(.podname)#\(.name)#\(.id)#\(.layerID)#\(.state)")' | column -ts'#' | sed -e 's/[ ]*$//' | sed -e "s/CONTAINER_EXITED/${redtext}Exited${resetcolor}/" -e "s/CONTAINER_RUNNING/${greentext}Running${resetcolor}/" -e "s/\(CONTAINER_[A-Za-z0-9]*\)/${yellowtext}Running${resetcolor}/"
+        echo ${IMAGE_JSON} | jq -r --arg image ${image} '" \\    Namespace#POD Name#Container Name#Container ID#Container Layer ID#State",(.[] | select(.status.id == $image) | .containers | sort_by(.namespace,.podname,.name) | .[]? | "  |-> \(.namespace)#\(.podname)#\(.name)#\(.id)#\(.layerID)#\(.state)")' | column -ts'#' | sed -e 's/[ ]*$//' | sed -e "s/CONTAINER_EXITED/${redtext}Exited${resetcolor}/" -e "s/CONTAINER_RUNNING/${greentext}Running${resetcolor}/" -e "s/\(CONTAINER_[A-Za-z0-9]*\)/${yellowtext}Running${resetcolor}/"
       fi
       echo -e "--------------------------------------------\n"
     done


### PR DESCRIPTION
- Rewriting the '-D' options based on feature requests '4283' for the 'sos' tool
- Option '-D' does now have 3 options 'sum','layers','both'
- Adding the option '-m' to filter the POD/containers based on the image ID, also filtering the '-D' option.
- Update the Readme.md accordingly + fix Readme format.
- Stopping the script when the 'PODPATH' does not exist and is required by the options.
- Fix missing 'echo -e' when using coloured messages.
- Adding supportability cross versions, as some fields have been added over time, such as the namespace in the 'crictl ps' output from 4.19.