### PR TITLE
Version 1.4.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,23 @@
 
 --------
 
+## Version 1.4.2
+
+### Minor updates - 1.4.2
+
+- None
+
+### Release updates - 1.4.2
+
+- Including the container space usage in the '-D' option from the crictl_stats, when available.
+- Script optimization to significally reduce the time to collect data and display layers.
+- Add an extra end-of-line for the 'INFO','WARN', 'ERR' messages to avoid any confusion, when multiple are triggered.
+- Fixing a typo in the 'Readme' where the uninstall commands are using the wrong alias.
+- Fixing a bug when the 'PODID' was not set properly when multiple POD Name were matching in the 'crictl_pods' file.
+- Fixing a typo where the 'PODPATH' was not set correctly when missing.
+
+--------
+
 ## Version 1.4.1
 
 ### Minor updates - 1.4.1

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sos4ocp_dir=$(dirname $(alias sos4ocp | cut -d"'" -f2)); cd ${sos4ocp_dir}; git 
 ### Remove the script (_based on the alias_)
 
 ```bash
-sos4ocp_dir=$(dirname $(alias mg_check | cut -d"'" -f2))
+sos4ocp_dir=$(dirname $(alias sos4ocp | cut -d"'" -f2))
 if [[ -d ${sos4ocp_dir} ]]; then rm -rf ${sos4ocp_dir}; fi
 sed -i -e "/alias sos4ocp/d" ${HOME}/.bashrc
 ```

--- a/sos4ocp.sh
+++ b/sos4ocp.sh
@@ -2,7 +2,7 @@
 ##################################################################
 # Script       # sos4ocp.sh
 # Description  # Display POD and related containers details
-# @VERSION     # 1.4.1
+# @VERSION     # 1.4.2
 ##################################################################
 # Changelog.md # List the modifications in the script.
 # README.md    # Describes the repository usage
@@ -111,7 +111,7 @@ fct_inspect(){
   FILENAME=$(ls -1 ${FILEPATH}* 2>/dev/null)
   if [[ -z ${FILENAME} ]]
   then
-    echo -e "\n${yellowtext}WARN: Unable to locate a ${1} file in the matching the PATH: ${FILEPATH}*${resetcolor}"
+    echo -e "\n${yellowtext}WARN: Unable to locate a ${1} file in the matching the PATH: ${FILEPATH}*${resetcolor}\n"
   else
     FCT_CMD="less ${FILENAME}"
     echo -e "\n${FCT_CMD}"
@@ -218,7 +218,7 @@ fct_container_statistic(){
 fct_cgroup(){
   if [[ ! -d ${PODPATH} ]]
   then
-    echo -e "${redtext}ERR: The <$PODPATH> does not exist and is required for this option\nPlease check the content of the sosreport${resetcolor}" && fct_help && exit 9
+    echo -e "${redtext}ERR: The <$PODPATH> does not exist and is required for this option\nPlease check the content of the sosreport${resetcolor}\n" && fct_help && exit 9
   fi
   POD_IDS_LIST=($(jq -r --arg cgroup "${CGROUP}" '.? | select(.info.runtimeSpec.linux.cgroupsPath | test($cgroup)) | "\(.status.id[0:13]) "' $(file ${PODPATH}/crictl_inspectp_* | grep -E "JSON data" | cut -d':' -f1) 2>/dev/null))
   if [[ -z ${POD_IDS_LIST} ]]
@@ -233,17 +233,17 @@ fct_check_proc_files(){
   WARN=0
   if [[ ! -f ${PS_GROUP} ]]
   then
-    echo -e "${yellowtext}WARN: File ${PS_GROUP} is missing${resetcolor}" | sed -e "s#[-0-9a-zA-Z._/]*\(sos_commands/process/[a-z\-_]*\)#\${SOSREPORT_PATH}/\1#g"
+    echo -e "${yellowtext}WARN: File ${PS_GROUP} is missing${resetcolor}\n" | sed -e "s#[-0-9a-zA-Z._/]*\(sos_commands/process/[a-z\-_]*\)#\${SOSREPORT_PATH}/\1#g"
     WARN=$[WARN + 1]
   fi
   if [[ ! -f ${PSFAUXWWW} ]]
   then
     if [[ ! -f ${PSAUXWWWM} ]]
     then
-      echo -e "${yellowtext}WARN: Files ${PSFAUXWWW} and ${PSAUXWWWM} are missing${resetcolor}" | sed -e "s#[-0-9a-zA-Z._/()]*\(sos_commands/process/[a-z\-_]*\)#\${SOSREPORT_PATH}/\1#g"
+      echo -e "${yellowtext}WARN: Files ${PSFAUXWWW} and ${PSAUXWWWM} are missing${resetcolor}\n" | sed -e "s#[-0-9a-zA-Z._/()]*\(sos_commands/process/[a-z\-_]*\)#\${SOSREPORT_PATH}/\1#g"
       WARN=$[WARN + 1]
     else
-      echo -e "${yellowtext}INFO: File ${PSFAUXWWW} is missing, using file ${PSAUXWWWM} instead${resetcolor}" | sed -e "s#[-0-9a-zA-Z._/()]*\(sos_commands/process/[a-z\-_]*\)#\${SOSREPORT_PATH}/\1#g"
+      echo -e "${yellowtext}INFO: File ${PSFAUXWWW} is missing, using file ${PSAUXWWWM} instead${resetcolor}\n" | sed -e "s#[-0-9a-zA-Z._/()]*\(sos_commands/process/[a-z\-_]*\)#\${SOSREPORT_PATH}/\1#g"
       PSFAUXWWW=${PSAUXWWWM}
     fi
   fi
@@ -258,7 +258,7 @@ fct_container_processes(){
   echo
   if [[ -z ${FILENAME} ]]
   then
-    echo -e "${yellowtext}WARN: Unable to locate a inspect file in the matching the PATH: ${FILEPATH}*${resetcolor}"
+    echo -e "${yellowtext}WARN: Unable to locate a inspect file in the matching the PATH: ${FILEPATH}*${resetcolor}\n"
   else
     Container_cgroup=$(jq -r '.info.runtimeSpec.linux.cgroupsPath' ${FILENAME} | sed -e "s/:crio:/\/crio-/")
     fct_check_proc_files
@@ -269,7 +269,7 @@ fct_container_processes(){
       PROCESS_LIST="$(grep ${Container_cgroup} ${PS_GROUP} 2>/dev/null| awk '{printf "|^[a-zA-Z0-9+ ]*"$1"|^[a-zA-Z0-9+ ]*"$2}')"
       grep -E "^USER${PROCESS_LIST}" ${PSFAUXWWW} | less
     else
-      echo -e "${redtext}ERR: Unable to retrieve the cgroup and/or PID as some files are missing.${resetcolor}"
+      echo -e "${redtext}ERR: Unable to retrieve the cgroup and/or PID as some files are missing.${resetcolor}\n"
     fi
   fi
 }
@@ -291,18 +291,34 @@ fct_image_size_overlay()
     fi
     #The Image reference in latest version is available in .status.imageId, but in older version it is only available in .info.runtimeSpec.annotations."io.kubernetes.cri-o.ImageRef", so we need to check both
     CONTAINER_DETAILS=$(jq -r '{ "name": .status.metadata.name, "id": .status.id, "imageId": (if (.status.imageId == null) then .info.runtimeSpec.annotations."io.kubernetes.cri-o.ImageRef" else .status.imageId end), "namespace": .status.labels."io.kubernetes.pod.namespace", "podname": .status.labels."io.kubernetes.pod.name", "state": .status.state, "layerID": (.info.runtimeSpec.root.path | split("/") | .[6])}' ${containerfile})
+    container_id=$(echo ${CONTAINER_DETAILS} | jq -r '.id' | cut -c1-13)
+    case ${CRICTL_STATS_TYPE} in
+      "name")
+        DISK_SPACE=$(awk -v container_id=${container_id} '{if($1 == container_id){disk_value=substr($5,1,length($5)-2);disk_unit=substr($5,length($5)-1);if(disk_unit=="GB"){stats=(disk_value * 1024)} else if(disk_unit=="TB"){stats=(disk_value * 1024 * 1024)} else if((disk_unit=="kB") || (disk_unit=="KB")){stats=(disk_value / 1024)} else {stats=disk_value}}}END{if (stats != ""){printf stats}else{printf 0}}' ${CRIO_PATH}/crictl_stats 2>/dev/null)
+        ;;
+      "other")
+        DISK_SPACE=$(awk -v container_id=${container_id} '{if($1 == container_id){disk_value=substr($4,1,length($4)-2);disk_unit=substr($4,length($4)-1);if(disk_unit=="GB"){stats=(disk_value * 1024)} else if(disk_unit=="TB"){stats=(disk_value * 1024 * 1024)} else if((disk_unit=="kB") || (disk_unit=="KB")){stats=(disk_value / 1024)} else {stats=disk_value}}}END{if (stats != ""){printf stats}else{printf 0}}' ${CRIO_PATH}/crictl_stats 2>/dev/null)
+        ;;
+      *)
+        DISK_SPACE=0
+        ;;
+    esac
+    CONTAINER_DETAILS=$(echo ${CONTAINER_DETAILS} | jq -r --arg disk_space "${DISK_SPACE}" '. + {"disk": $disk_space}')
     CONTAINER_LIST=$( echo ${CONTAINER_LIST} | jq -rc --argjson container_details "${CONTAINER_DETAILS}" '. + [ $container_details ]')
   done
-  SHARED_LAYERS=$(jq -rs '.[].info.imageSpec.rootfs."diff_ids"[]' $(file ${IMAGEPATH}/crictl_inspecti_* 2>/dev/null | grep -E "JSON data" | cut -d':' -f1) | sort | uniq -c | sort -n | grep -Ev "^ *1 sha256" | awk 'BEGIN{printf"["}{printf "{\"%s\":{\"count\":%d}},",$2,$1}END{printf"]\n"}' | sed -e "s/,\]/\]/")
+  # Collect the shared layers across all images and count the number of images sharing each layer.
+  SHARED_LAYERS=$(jq -rs '.[].info.imageSpec.rootfs."diff_ids"[]' $(file ${IMAGEPATH}/crictl_inspecti_* 2>/dev/null | grep -E "JSON data" | cut -d':' -f1) | sort | uniq -c | sort -n | grep -Ev "^ *1 sha256" | awk '{printf "%s+%d\n",$2,$1}')
   # Calculate the replicate space used by each shared layer
   SHARED_LAYER_JSON="[]"
-  for sha256_layer in $(echo ${SHARED_LAYERS} | jq -r '.[] | keys[]')
+  for sha256_layer in ${SHARED_LAYERS}
   do
+    layer_id=$(echo ${sha256_layer} | cut -d'+' -f1)
+    count=$(echo ${sha256_layer} | cut -d'+' -f2)
     if [[ -f ${OVERLAY_LAYERS_FILE} ]]
     then
-      SHARED_LAYER_DETAILS=$(jq -r --arg layer "${sha256_layer}" --argjson sharedlayers ${SHARED_LAYERS} '.[] | select(."diff-digest" == $layer) | {"diff-digest",id,parent,"diff-size","count":($sharedlayers[]? | to_entries[] | select(.key == $layer) | .value.count)}' ${OVERLAY_LAYERS_FILE})
+      SHARED_LAYER_DETAILS=$(jq -r --arg layer ${layer_id} --arg count ${count} '.[] | select(."diff-digest" == $layer) | {"diff-digest",id,parent,"diff-size","count":$count}' ${OVERLAY_LAYERS_FILE})
     else
-      SHARED_LAYER_DETAILS=$(jq -n --arg layer "${sha256_layer}" --argjson sharedlayers ${SHARED_LAYERS} '{"diff-digest": $layer, "id": null, "parent": null, "diff-size": null, "count": ($sharedlayers[]? | to_entries[] | select(.key == $layer) | .value.count)}')
+      SHARED_LAYER_DETAILS=$(jq -n --arg layer ${layer_id} --arg count ${count} '{"diff-digest": $layer, "id": null, "parent": null, "diff-size": null, "count": $count}')
     fi
     SHARED_LAYER_JSON=$(echo ${SHARED_LAYER_JSON} | jq -rc --argjson layer_details "${SHARED_LAYER_DETAILS}" '. + [ $layer_details ]')
   done
@@ -332,45 +348,55 @@ fct_image_size_overlay()
     LAYER_JSON="[]"
     for sha256_layer in ${SHA256_IMAGE_LAYERS}
     do
-      SHARED_LAYER_BOOL=$(echo ${SHARED_LAYERS} | jq -r --arg layer "${sha256_layer}" '(.[] | to_entries[] | select(.key == $layer)| if (.key == $layer) then true else $layer end) // false')
+      SHARED_LAYER_BOOL=$(echo ${SHARED_LAYER_JSON} | jq -r --arg layer "${sha256_layer}" '(.[] | select(."diff-digest" == $layer)| if (."diff-digest" == $layer) then true else false end) // false')
       if [[ -f ${OVERLAY_LAYERS_FILE} ]]
       then
-        LAYER_DETAILS=$(jq -r --arg layer "${sha256_layer}" --arg shared ${SHARED_LAYER_BOOL} '.[] | select(."diff-digest" == $layer) | {"diff-digest",id,parent,"diff-size","shared":$shared}' ${OVERLAY_LAYERS_FILE})
+        LAYER_DETAILS=$(jq -r --arg layer "${sha256_layer}" --arg shared ${SHARED_LAYER_BOOL} '(.[] | select(."diff-digest" == $layer) | {"diff-digest",id,parent,"diff-size","shared":$shared}) // {"diff-digest": $layer, "id": null, "parent": null, "diff-size": null, "shared": $shared}' ${OVERLAY_LAYERS_FILE})
       else
         LAYER_DETAILS=$(jq -n --arg layer "${sha256_layer}" --arg shared ${SHARED_LAYER_BOOL} '{"diff-digest": $layer, "id": null, "parent": null, "diff-size": null, "shared": $shared}')
       fi
       LAYER_JSON=$(echo ${LAYER_JSON} | jq -rc --argjson layer_details "${LAYER_DETAILS}" '. + [ $layer_details ]')
     done
-    CONTAINER_MATCH=$(echo ${CONTAINER_LIST} | jq -r --arg imageid ${IMAGE_ID} '.[] | select(.imageId == $imageid) | {name, id: .id[0:13], layerID, state, namespace, podname}' | jq -s)
-    IMAGE_JSON=$(echo ${IMAGE_JSON} | jq -rc --argjson image_status "${IMAGE_STATUS}" --argjson containers "${CONTAINER_MATCH}" --argjson layer_json "${LAYER_JSON}" '. + [ {"status": $image_status, "containers": $containers, "layers": $layer_json} ]')
+    CONTAINER_MATCH=$(echo ${CONTAINER_LIST} | jq -r --arg imageid ${IMAGE_ID} '.[] | select(.imageId == $imageid) | {name, id: .id[0:13], layerID, state, namespace, podname, disk: (.disk | tonumber * 1000 | round /1000)}' | jq -s)
+    # Creating a specific variable for each image to split the original huge variable.
+    declare IMAGE_${IMAGE_ID}=$(echo "${IMAGE_STATUS}" | jq -rc --argjson containers "${CONTAINER_MATCH}" --argjson layer_json "${LAYER_JSON}" '[ {"status": ., "containers": $containers, "layers": $layer_json} ]')
+    # Creating a global with limited data used only for global summary.
+    IMAGE_JSON=$(echo ${IMAGE_JSON} | jq -rc --argjson image_status "${IMAGE_STATUS}" --argjson containers "${CONTAINER_MATCH}" --argjson layer_json "${LAYER_JSON}" '. + [ {"status": {"id": $image_status.id, "size": $image_status.size}, "containers": [ ($containers | .[].id) ], "layers": [ ($layer_json | .[] | {"diff-size", shared})] } ]')
   done
   echo
   clear
 
   if [[ -z ${IMAGEID} ]]
   then
-    echo -e "############################################"
-    echo ${IMAGE_JSON} | jq -rc --argjson containers "${CONTAINER_LIST}" --argjson sharedlayerjson ${SHARED_LAYER_JSON} '(. | length) as $nbimages | ($containers | length) as $nbcontainers | ([.[] | .status.size | tonumber] | add * 100/1024/1024 | round/100) as $total | ([$sharedlayerjson | .[]? | ((."diff-size" // 0) | tonumber) * (((.count // 1) | tonumber) -1) ] | add * 100/1024/1024 | round/100) as $duplicshared | "# Number of Images:|\($nbimages)\n# Number of Containers:|\($nbcontainers)\n#########################\n# TOTAL IMAGE SIZE:|\($total) MB\n# DUPLICATE SHARED SPACE:|\(if($duplicshared > 0) then "-\($duplicshared) MB" else "Unknown" end)\n# USED SPACE ON DISK:|\(if($duplicshared > 0) then "\(($total - $duplicshared) * 100 | round /100) MB" else "Unknown" end)"' | column -ts'|' | sed -e 's/[ \t]*$//' -e "s/\(DUPLICATE SHARED SPACE: *\)\([0-9.-]*\) MB/\1${cyantext}\2${resetcolor} MB/" -e "s/\(DUPLICATE SHARED SPACE: *\)\([A-Za-z]*\)/\1${cyantext}\2${resetcolor}/" -e "s/\(TOTAL IMAGE SIZE: *\)\([0-9.]*\) MB/\1${yellowtext}\2${resetcolor} MB/" -e "s/\(USED SPACE ON DISK: *\)\([0-9.]*\) MB/\1${greentext}\2${resetcolor} MB/" -e "s/\(USED SPACE ON DISK: *\)\([A-Za-z]*\)/\1${yellowtext}\2${resetcolor}/"
-    echo -e "############################################"
+    echo -e "##################################################"
+    echo ${IMAGE_JSON} | jq -rc --argjson containers "${CONTAINER_LIST}" '(. | length) as $nbimages | ($containers | length) as $nbcontainers |"# Number of Images:|\($nbimages)\n# Number of Containers:|\($nbcontainers)"' | column -ts'|' | sed -e 's/[ \t]*$//'
+    echo -e "##################################################"
+    echo ${IMAGE_JSON} | jq -rc --argjson containers "${CONTAINER_LIST}" --argjson sharedlayerjson ${SHARED_LAYER_JSON} '([.[] | (.status.size // 0) | tonumber] | add * 100/1024/1024 | round/100) as $total | ([$sharedlayerjson | .[]? | ((."diff-size" // 0) | tonumber) * (((.count // 1) | tonumber) -1) ] | add * 100/1024/1024 | round/100) as $duplicshared | ([($containers | .[] | ((if (.disk == "null") then 0 else .disk end) // 0 | tonumber))] | add * 100 | round / 100) as $containersize|  "# TOTAL IMAGE SIZE:|\($total)|MB\n# DUPLICATE SHARED LAYERS SPACE:|\(if($duplicshared > 0) then "-\($duplicshared)|MB" else "Unknown" end)\n# CONTAINER LAYERS SPACE ON DISK:|\(if($containersize > 0) then "\($containersize)|MB" else "Unknown" end)\n# TOTAL USED SPACE ON DISK:|\(if(($duplicshared > 0) and ($containersize > 0)) then "\(($total - $duplicshared + $containersize) * 100 | round /100)|MB" else "Unknown" end)"' | column -ts'|' | sed -e 's/[ \t]*$//' -e "s/\(DUPLICATE SHARED LAYERS SPACE: *\)\([0-9.-]*\)/\1${purpletext}\2${resetcolor}/" -e "s/\(DUPLICATE SHARED LAYERS SPACE: *\)\([A-Za-z]*\)/\1${yellowtext}\2${resetcolor}/" -e "s/\(TOTAL IMAGE SIZE: *\)\([0-9.]*\)/\1${yellowtext}\2${resetcolor}/" -e "s/\(TOTAL USED SPACE ON DISK: *\)\([0-9.]*\)/\1${greentext}\2${resetcolor}/" -e "s/\(TOTAL USED SPACE ON DISK: *\)\([A-Za-z]*\)/\1${yellowtext}\2${resetcolor}/" -e "s/\(CONTAINER LAYERS SPACE ON DISK: *\)\([0-9.]*\)/\1${cyantext}\2${resetcolor}/" -e "s/\(CONTAINER LAYERS SPACE ON DISK: *\)\([A-Za-z]*\)/\1${yellowtext}\2${resetcolor}/"
+    echo -e "##################################################"
   fi
+
   if [[ ${DISKPRESSURE} == "sum" ]] || [[ ${DISKPRESSURE} == "both" ]]
   then
     echo -e "\n############################################\n# IMAGES SUMMARY\n############################################\n"
-    echo -e ${IMAGE_JSON} | jq -r '"Image| |Shared Layers| |Unique Layers| |Containers|\nID|Size|Size|Count|Size|Count|Count|",(sort_by(-(.status.size | tonumber)) | .[] | ((.status.size | tonumber) *100 /1024 /1024 | round/100) as $image_size | (.layers | map(select(.shared == "true"))) as $shared_layer | (.layers | map(select(.shared == "false"))) as $unique_layer | "\(.status.id)|\($image_size) MB|\([ $shared_layer | (.[]?."diff-size" // 0) | tonumber] | add | if(($shared_layer |length > 0) and ((. == 0) or (. == null))) then "Unknown" else if(. == null) then 0 else (. /1024 /1024 * 100 | round/100) end end) MB|(\($shared_layer |length))|\([ $unique_layer | (.[]?."diff-size" // 0) | tonumber] | add | if(($unique_layer |length > 0) and ((. == 0) or (. == null))) then "Unknown" else if(. == null) then 0 else (. /1024 /1024 * 100 | round/100) end end) MB|(\($unique_layer |length))|\(.containers | length)")' | column -ts'|' | sed -e 's/[ ]*$//' -e "s/\([0-9]\{4,10\}\.*[0-9]*\) MB/${redtext}\1${resetcolor} MB/g" -e "s/\([0-9]\{4,10\}\) MB/${redtext}\1${resetcolor} MB/g" -e "s/\([4-9][0-9]\{2\}\.[0-9]*\) MB/${yellowtext}\1${resetcolor} MB/g" -e "s/\([4-9][0-9]\{2\}\) MB/${yellowtext}\1${resetcolor} MB/g"
+    echo -e ${IMAGE_JSON} | jq -r '"Image| |Shared Layers| |Unique Layers| |Containers|\nID|Size|Size|Count|Size|Count|Count|",(sort_by(-(.status.size | tonumber)) | .[] | ((.status.size | tonumber) *100 /1024 /1024 | round/100) as $image_size | (.layers | map(select(.shared == "true"))) as $shared_layer | ([ $shared_layer | (.[]?."diff-size" // 0) | tonumber] | add | if(($shared_layer |length > 0) and ((. == 0) or (. == null))) then "Unknown" else if(. == null) then 0 else (. /1024 /1024 * 100 | round/100) end end) as $shared_size | (.layers | map(select(.shared == "false"))) as $unique_layer | ([ $unique_layer | (.[]?."diff-size" // 0) | tonumber] | add | if(($unique_layer |length > 0) and ((. == 0) or (. == null))) then "Unknown" else if(. == null) then 0 else (. /1024 /1024 * 100 | round/100) end end) as $unique_size | "\(.status.id)|\($image_size) MB|\($shared_size) MB|(\($shared_layer |length))|\($unique_size) MB|(\($unique_layer |length))|\(.containers | length)")' | column -ts'|' | sed -e 's/[ ]*$//' -e "s/\([0-9]\{4,10\}\.*[0-9]*\) MB/${redtext}\1${resetcolor} MB/g" -e "s/\([0-9]\{4,10\}\) MB/${redtext}\1${resetcolor} MB/g" -e "s/\([4-9][0-9]\{2\}\.[0-9]*\) MB/${yellowtext}\1${resetcolor} MB/g" -e "s/\([4-9][0-9]\{2\}\) MB/${yellowtext}\1${resetcolor} MB/g"
   fi
   if [[ ${DISKPRESSURE} == "layers" ]] || [[ ${DISKPRESSURE} == "both" ]]
   then
     echo -e "\n############################################\n# IMAGE LAYERS DETAILS\n############################################\n"
-    for image in $(echo ${IMAGE_JSON} | jq -r 'sort_by(-(.status.size | tonumber)) | .[] | .status.id')
+
+    for ID_ARRAY_SPLIT in $(echo ${IMAGE_JSON} | jq -r 'sort_by(-(.status.size | tonumber)) | .[].status.id')
     do
-      echo ${IMAGE_JSON} | jq -r --arg image ${image} '.[] | select(.status.id == $image) | .status | "Image ID: \(.id) - Repotag: \(.repoTags) - Repodigest: \(.repoDigests)"' | sed -e "s/\(Image ID:\)/${greentext}\1${resetcolor}/"
-      echo ${IMAGE_JSON} | jq -r --arg image ${image} '.[] | select(.status.id == $image) | ((.status.size | tonumber) *100 /1024 /1024 | round/100) as $image_size | (.layers | map(select(.shared == "true"))) as $shared_layer | (.layers | map(select(.shared == "false"))) as $unique_layer | " |-> Size: \($image_size) MB  / Shared layers: \($shared_layer |length) (\([ $shared_layer | (.[]?."diff-size" // 0) | tonumber] | add | if(($shared_layer |length > 0) and ((. == 0) or (. == null))) then "Unknown" else if(. == null) then 0 else (. /1024 /1024 * 100 | round/100) end end) MB) / Unique layers: \($unique_layer |length) (\([ $unique_layer | (.[]?."diff-size" // 0) | tonumber] | add | if(($unique_layer |length > 0) and ((. == 0) or (. == null))) then "Unknown" else if(. == null) then 0 else (. /1024 /1024 * 100 | round/100) end end) MB)"' | sed -e "s/\([0-9]\{4,10\}\.[0-9]*\) MB/${redtext}\1${resetcolor} MB/g" -e "s/\([4-9][0-9]\{2\}\.[0-9]*\) MB/${yellowtext}\1${resetcolor} MB/g" -e "s/Unknown/${yellowtext}Unknown${resetcolor}/g"
-      echo -e " |-> ${purpletext}Layers${resetcolor} ($(echo ${IMAGE_JSON} | jq -r --arg image ${image} '.[] | select(.status.id == $image) | .layers | length'))"
-      echo ${IMAGE_JSON} | jq -r --arg image ${image} '" \\    Sha256#Layer ID#Layer Size#Parent#Shared",(.[] | select(.status.id == $image) | .layers[]? | "  |-> \(."diff-digest")#\(.id)#\(if(."diff-size" != null) then "\(."diff-size"|tonumber /1024 /1024 * 100 | round/100) MB" else "Unknown" end)#\(.parent)#\(.shared)\n")' | column -ts'#' | sed -e 's/[ ]*$//' -e "s/true$/${yellowtext}true${resetcolor}/" -e "s/\([0-9]\{4,10\}\.[0-9]*\) MB/${redtext}\1${resetcolor} MB/g" -e "s/\([4-9][0-9]\{2\}\.[0-9]*\) MB/${yellowtext}\1${resetcolor} MB/g" -e "s/Unknown/${yellowtext}Unknown${resetcolor}/g"
-      echo -e " |-> ${cyantext}Containers${resetcolor} ($(echo ${IMAGE_JSON} | jq -r --arg image ${image} '.[] | select(.status.id == $image) | .containers | length'))"
-      if [[ $(echo ${IMAGE_JSON} | jq -r --arg image ${image} '.[] | select(.status.id == $image) | .containers | length') != 0 ]]
+      ARRAY_INDEX="IMAGE_${ID_ARRAY_SPLIT}"
+      # Retrieve the dedicated array for the current image.
+      SPLIT_ARRAY=${!ARRAY_INDEX}
+      echo ${SPLIT_ARRAY} | jq -r '.[] | .status | "Image ID: \(.id) - Repotag: \(.repoTags) - Repodigest: \(.repoDigests)"' | sed -e "s/\(Image ID:\)/${greentext}\1${resetcolor}/"
+      echo ${SPLIT_ARRAY} | jq -r '.[] | ((.status.size | tonumber) *100 /1024 /1024 | round/100) as $image_size | (.layers | map(select(.shared == "true"))) as $shared_layer | (.layers | map(select(.shared == "false"))) as $unique_layer | " |-> Size: \($image_size) MB  / Shared layers: \($shared_layer |length) (\([ $shared_layer | (.[]?."diff-size" // 0) | tonumber] | add | if(($shared_layer |length > 0) and ((. == 0) or (. == null))) then "Unknown" else if(. == null) then 0 else (. /1024 /1024 * 100 | round/100) end end) MB) / Unique layers: \($unique_layer |length) (\([ $unique_layer | (.[]?."diff-size" // 0) | tonumber] | add | if(($unique_layer |length > 0) and ((. == 0) or (. == null))) then "Unknown" else if(. == null) then 0 else (. /1024 /1024 * 100 | round/100) end end) MB)"' | sed -e "s/\([0-9]\{4,10\}\.[0-9]*\) MB/${redtext}\1${resetcolor} MB/g" -e "s/\([4-9][0-9]\{2\}\.[0-9]*\) MB/${yellowtext}\1${resetcolor} MB/g" -e "s/Unknown/${yellowtext}Unknown${resetcolor}/g"
+      echo -e " |-> ${purpletext}Layers${resetcolor} ($(echo ${SPLIT_ARRAY} | jq -r '.[].layers | length'))"
+      echo ${SPLIT_ARRAY} | jq -r '" \\    Sha256#Layer ID#Layer Size#Parent#Shared",(.[].layers[]? | "  |-> \(."diff-digest")#\(.id)#\(if(."diff-size" != null) then "\(."diff-size"|tonumber /1024 /1024 * 100 | round/100) MB" else "Unknown" end)#\(.parent)#\(.shared)\n")' | column -ts'#' | sed -e 's/[ ]*$//' -e "s/true$/${yellowtext}true${resetcolor}/" -e "s/\([0-9]\{4,10\}\.[0-9]*\) MB/${redtext}\1${resetcolor} MB/g" -e "s/\([4-9][0-9]\{2\}\.[0-9]*\) MB/${yellowtext}\1${resetcolor} MB/g" -e "s/Unknown/${yellowtext}Unknown${resetcolor}/g"
+      echo -e " /\n |-> ${cyantext}Containers${resetcolor} ($(echo ${SPLIT_ARRAY} | jq -r '.[].containers | length'))"
+      if [[ $(echo ${SPLIT_ARRAY} | jq -r '.[].containers | length') != 0 ]]
       then
-        echo ${IMAGE_JSON} | jq -r --arg image ${image} '" \\    Namespace#POD Name#Container Name#Container ID#Container Layer ID#State",(.[] | select(.status.id == $image) | .containers | sort_by(.namespace,.podname,.name) | .[]? | "  |-> \(.namespace)#\(.podname)#\(.name)#\(.id)#\(.layerID)#\(.state)")' | column -ts'#' | sed -e 's/[ ]*$//' | sed -e "s/CONTAINER_EXITED/${redtext}Exited${resetcolor}/" -e "s/CONTAINER_RUNNING/${greentext}Running${resetcolor}/" -e "s/\(CONTAINER_[A-Za-z0-9]*\)/${yellowtext}Running${resetcolor}/"
+        echo ${SPLIT_ARRAY} | jq -r '" \\    Namespace#POD Name#Container Name#Container ID#Container Layer ID#Layer Used Space#State",(.[].containers | sort_by(.namespace,.podname,.name) | .[]? | "  |-> \(.namespace)#\(.podname)#\(.name)#\(.id)#\(.layerID)#\(.disk) MB#\(.state)")' | column -ts'#' | sed -e 's/[ ]*$//' | sed -e "s/CONTAINER_EXITED/${redtext}Exited${resetcolor}/" -e "s/CONTAINER_RUNNING/${greentext}Running${resetcolor}/" -e "s/\(CONTAINER_[A-Za-z0-9]*\)/${yellowtext}Running${resetcolor}/"
       fi
       echo -e "--------------------------------------------\n"
     done
@@ -562,20 +588,20 @@ CRIO_PATH=${SOSREPORT_PATH}/sos_commands/crio
 LOGPATH=${LOGPATH:-$(dirname $(find  ${CRIO_PATH}/ -name "crictl_logs_*")  2>/dev/null | sort -u)}
 if [[ -z ${LOGPATH} ]]
 then
-  echo -e "${yellowtext}WARN: Unable to find any crictl_logs_\* file in the crio folder: ${CRIO_PATH}\nSetting the variable \$LOGPATH to the default: \${CRIO_PATH}/logs ${resetcolor}"
+  echo -e "${yellowtext}WARN: Unable to find any crictl_logs_\* file in the crio folder: ${CRIO_PATH}\nSetting the variable \$LOGPATH to the default: \${CRIO_PATH}/logs ${resetcolor}\n"
   LOGPATH=${CRIO_PATH}/logs
 fi
 CONTAINERPATH=${CONTAINERPATH:-$(dirname $(find  ${CRIO_PATH}/ -name "crictl_inspect_*")  2>/dev/null | sort -u)}
 if [[ -z ${CONTAINERPATH} ]]
 then
-  echo -e "${yellowtext}WARN: Unable to find any crictl_inspect_\* file in the crio folder: ${CRIO_PATH}\nSetting the variable \$CONTAINERPATH to the default: \${CRIO_PATH}/containers ${resetcolor}"
+  echo -e "${yellowtext}WARN: Unable to find any crictl_inspect_\* file in the crio folder: ${CRIO_PATH}\nSetting the variable \$CONTAINERPATH to the default: \${CRIO_PATH}/containers ${resetcolor}\n"
   CONTAINERPATH=${CRIO_PATH}/containers
 fi
 PODPATH=${PODPATH:-$(dirname $(find  ${CRIO_PATH}/ -name "crictl_inspectp*")  2>/dev/null | sort -u)}
 if [[ -z ${PODPATH} ]]
 then
-  echo -e "${yellowtext}WARN: Unable to find any crictl_inspectp_\* file in the crio folder: ${CRIO_PATH}\nSetting the variable \$PODPATH to the default: \${CRIO_PATH}/pods ${resetcolor}"
-  PODPATH=${PODPATH}/pods
+  echo -e "${yellowtext}WARN: Unable to find any crictl_inspectp_\* file in the crio folder: ${CRIO_PATH}\nSetting the variable \$PODPATH to the default: \${CRIO_PATH}/pods ${resetcolor}\n"
+  PODPATH=${CRIO_PATH}/pods
 fi
 
 if [[ ! -f ${CRIO_PATH}/crictl_pods ]] || [[ ! -f ${CRIO_PATH}/crictl_ps_-a ]]
@@ -593,6 +619,20 @@ PSFAUXWWW="${SOSREPORT_PATH}/sos_commands/process/ps_auxfwww"
 PSAUXWWWM="${SOSREPORT_PATH}/sos_commands/process/ps_auxwwwm"
 PS_GROUP="${SOSREPORT_PATH}/sos_commands/process/ps_axo_pid_ppid_user_group_lwp_nlwp_start_time_comm_cgroup"
 
+# Check the type of crictl_stats files here as used in all options.
+if [[ -f ${CRIO_PATH}/crictl_stats ]] && [[ -z $(grep "level=fatal msg=" ${CRIO_PATH}/crictl_stats 2>/dev/null) ]]
+then
+  if [[ $(awk 'BEGIN{namepresence="false"}{if($2 == "NAME"){namepresence="true"}}END{print namepresence}' ${CRIO_PATH}/crictl_stats) == "true" ]]
+  then
+    CRICTL_STATS_TYPE=name
+  else
+    CRICTL_STATS_TYPE=other
+  fi
+else
+  echo -e "${yellowtext}WARN: The file crictl_stats is missing or invalid. Unable to provide the PODs' statistics${resetcolor}\n"
+  CRICTL_STATS_TYPE=none
+fi
+
 if [[ ! -z ${DISKPRESSURE} ]]
 then
   OVERLAY_LAYERS_FILE=${SOSREPORT_PATH}/var/lib/containers/storage/overlay-layers/layers.json
@@ -603,133 +643,118 @@ then
   fi
   if [[ -z ${CONTAINERPATH} ]]
   then
-    echo -e "${yellowtext}WARN: container inspect files are missing. Unable to correlate the image size with the container name and ids${resetcolor}"
+    echo -e "${yellowtext}WARN: container inspect files are missing. Unable to correlate the image size with the container name and ids${resetcolor}\n"
   fi
   if [[ -f ${OVERLAY_LAYERS_FILE} ]]
   then
     fct_image_size_overlay
   else
-    echo -e "${yellowtext}WARN: Unable to find the overlay layers file in the sosreport (<SOSREPORT_PATH>/var/lib/containers/storage/overlay-layers/layers.json).\nThe image size will be calculated based on the crictl_inspecti_* files only, without correlating with the shared layers sizes.${resetcolor}"
+    echo -e "${yellowtext}WARN: Unable to find the overlay layers file in the sosreport (<SOSREPORT_PATH>/var/lib/containers/storage/overlay-layers/layers.json).\nThe image size will be calculated based on the crictl_inspecti_* files only, without correlating with the shared layers sizes.${resetcolor}\n"
     fct_image_size_overlay
-    echo -e "${yellowtext}WARN: Unable to find the overlay layers file in the sosreport (<SOSREPORT_PATH>/var/lib/containers/storage/overlay-layers/layers.json).\nThe image size will be calculated based on the crictl_inspecti_* files only, without correlating with the shared layers sizes.${resetcolor}"
+    echo -e "\n${yellowtext}WARN: Unable to find the overlay layers file in the sosreport (<SOSREPORT_PATH>/var/lib/containers/storage/overlay-layers/layers.json).\nThe image size will be calculated based on the crictl_inspecti_* files only, without correlating with the shared layers sizes.${resetcolor}\n"
   fi
   exit 0
 fi
 
 clear
 
-#Check the crictl_ps_-a file to be able to correlate the POD ID based on the collected data
+#Check the crictl_ps_-a file to be able to correlate the POD ID based on the collected data in the crictl_ps_-a file.
 PODID_POSITION=$(head -1 ${CRIO_PATH}/crictl_ps_-a 2>/dev/null | awk '{if($NF == "NAMESPACE"){print "2"}else if($NF == "POD"){print "1"}else{print "0"}}')
+
+#Checking the number of options provided and set the POD_LIST variable with the corresponding POD IDs based on the provided option or with all the PODs if no option is provided
 if [[ ${OPTNUM} == 0 ]]
 then
   POD_LIST=($(awk '{if(($1 != "POD") && ($1 !~ "^time=")){printf "%s,%s,%s,%s\n",$1,$(NF-3),$(NF-2),$(NF-4)}}' ${CRIO_PATH}/crictl_pods 2>/dev/null | sort -r -k 4 -k3 -t',' | awk '{printf "%s ",$0}'))
   fct_pod_list_menu
 else
-  if [[ "${PODID}" == "null" ]] && [[ "${PODNAME}" == "null" ]]
-  then
-    case ${PODFILTER} in
-      "CONTAINER")
-        POD_IDS_LIST=($(awk -v containername=${CONTAINERNAME} -v position=${PODID_POSITION} '{if($(NF-position-2) == containername){print $(NF-position)}}' ${CRIO_PATH}/crictl_ps_-a 2>/dev/null | sort -u  | awk '{printf "%s ",$0}'))
-        echo -e "List of PODs including the container: ${CONTAINERNAME}\n"
-        ;;
-      "CONTAINERID")
-        fct_extract_from_container_id
-        echo -e "List of PODs including the container ID: ${CONTAINERID}\n"
-        ;;
-      "CGROUP")
-        fct_cgroup
-        echo -e "List of PODs including the cgroup: ${CGROUP}\n"
-        ;;
-      "IMAGE")
-        POD_IDS_LIST=($(awk -v imageid=${IMAGEID} -v position=${PODID_POSITION} '{if($(2) == imageid){print $(NF-position)}}' ${CRIO_PATH}/crictl_ps_-a 2>/dev/null | sort -u | awk '{printf "%s ",$0}'))
-        echo -e "List of PODs including the image ID: ${IMAGEID}\n"
-        ;;
-      "NAMESPACE")
-        POD_IDS_LIST=($(awk -v pod_namespace=${NAMESPACE} '{if($(NF-2) == pod_namespace){printf "%s ",$1}}' ${CRIO_PATH}/crictl_pods 2>/dev/null))
-        echo -e "List of PODs from the namespce: ${NAMESPACE}\n"
-        ;;
-      "STATISTIC")
-        if [[ -f ${CRIO_PATH}/crictl_stats ]] && [[ -z $(grep "level=fatal msg=" ${CRIO_PATH}/crictl_stats 2>/dev/null) ]]
-        then
-          POD_DETAILS=$(grep -Ev "^POD" ${CRIO_PATH}/crictl_pods)
-          CONTAINER_DETAILS=$(awk '{if($1 != "CONTAINER"){print}}' ${CRIO_PATH}/crictl_ps_-a 2>/dev/null | sed -e "s/About \([a-z]*\) \([a-z]*\) ago/About_\1_\2_ago/" -e "s/\([0-9]*\) \([a-z]*\) ago/\1_\2_ago/")
-          if [[ $(head -1 ${CRIO_PATH}/crictl_ps_-a | awk '{print $NF}') == "POD" ]]
-          then
-            CONTAINER_IDS=($(echo "${CONTAINER_DETAILS}" |awk '{printf "%s|%s|%s|%s|%s|%s|%s ",$7,$8,$1,$5,$4,$3,$6}'))
-          else
-            CONTAINER_IDS=($(echo "${CONTAINER_DETAILS}" |awk '{printf "%s|%s|%s|%s|%s|%s|%s ",$7,"-",$1,$5,$4,$3,$6}'))
-          fi
-        else
-          echo -e "${yellowtext}WARN: Unable to proceed with the PODs' statistics${resetcolor}"
-          if [[ ! -f ${CRIO_PATH}/crictl_stats ]]
-          then
-            echo -e "${redtext}ERR: Unable to find the stats file: ${CRIO_PATH}/crictl_stats\n${resetcolor}" && fct_help && exit 7
-          else
-            echo -e "${redtext}ERR: Fatal error detected in the stats file: ${CRIO_PATH}/crictl_stats\n${resetcolor}" && fct_help && exit 8
-          fi
-        fi
-        ;;
-      "OVERLAY")
-        if [[ ! -d ${PODPATH} ]]
-        then
-          echo -e "${redtext}ERR: The <$PODPATH> does not exist and is required for this option\nPlease check the content of the sosreport${resetcolor}" && fct_help && exit 9
-        fi
-        POD_IDS_LIST=($(jq -r --arg overlay "${OVERLAY}" '.? | select(.info.runtimeSpec.root.path | test($overlay)) | "\(.status.id[0:13]) "' $(file ${PODPATH}/crictl_inspectp_* | grep -E "JSON data" | cut -d':' -f1) 2>/dev/null))
-        if [[ -z ${POD_IDS_LIST} ]]
-        then
-          CONTAINERID=$(jq -r --arg overlay "$(echo ${OVERLAY} | sed -e "s/crio-//")" '.? | select(.info.runtimeSpec.root.path | test($overlay)) | "\(.status.id[0:13])"' $(file ${CONTAINERPATH}/crictl_inspect* | grep -E "JSON data" | cut -d':' -f1) 2>/dev/null)
-          fct_extract_from_container_id
-        fi
-        echo -e "List of PODs including the overlay: ${OVERLAY}\n"
-        ;;
-      "PROCPID")
-        fct_check_proc_files
-        WARN=$?
-        if [[ ${WARN} == 0 ]]
-        then
-          CGROUP="$(awk -v  procid=${PROC_PID} '{if($1 == procid){print}}' ${PS_GROUP} 2>/dev/null | sed -e "s/.*crio-[a-z-]*\([0-9a-zA-Z_]*\).scope.*/\1/")"
-          if [[ ! -z ${CGROUP} ]]
-          then
-            fct_cgroup
-          fi
-        else
-          echo -e "${redtext}ERR: Unable to retrieve the Process ID details as the process files are missing.${resetcolor}"
-        fi
-        echo -e "List of PODs including the PROC_PID: ${PROC_PID}\n"
-        ;;
-      "PODUID")
-        if [[ ! -d ${PODPATH} ]]
-        then
-          echo -e "${redtext}ERR: The <$PODPATH> does not exist and is required for this option\nPlease check the content of the sosreport${resetcolor}" && fct_help && exit 9
-        fi
-        POD_IDS_LIST=($(jq -r --arg poduid "${PODUID}" '.? | select(.status.metadata.uid == $poduid) | "\(.status.id[0:13]) "' $(file ${PODPATH}/crictl_inspectp_* | grep -E "JSON data" | cut -d':' -f1) 2>/dev/null))
-        echo -e "List of PODs including the POD_UID: ${PODUID}\n"
-        ;;
-    esac
-    if [[ ${#POD_IDS_LIST[@]} == 1 ]]
-    then
-      PODID=${POD_IDS_LIST[0]}
-    else
-      if [[ ${#POD_IDS_LIST[@]} -ge 2 ]]
+  case ${PODFILTER} in
+    "NAME")
+      POD_IDS_LIST=($(awk -v podname=${PODNAME} '{if($(NF-3) == podname){print $1}}' ${CRIO_PATH}/crictl_pods 2>/dev/null | sort -u | awk '{printf "%s ",$0}'))
+      echo -e "List of PODs including the name: ${PODNAME}\n"
+      PODNAME="null"
+      ;;
+    "ID")
+      POD_IDS_LIST=($(awk -v podid=${PODID} '{if($1 == podid){print $1}}' ${CRIO_PATH}/crictl_pods 2>/dev/null | sort -u | awk '{printf "%s ",$0}'))
+      echo -e "List of PODs including the ID: ${PODID}\n"
+      PODID="null"
+      ;;
+    "CONTAINER")
+      POD_IDS_LIST=($(awk -v containername=${CONTAINERNAME} -v position=${PODID_POSITION} '{if($(NF-position-2) == containername){print $(NF-position)}}' ${CRIO_PATH}/crictl_ps_-a 2>/dev/null | sort -u  | awk '{printf "%s ",$0}'))
+      echo -e "List of PODs including the container: ${CONTAINERNAME}\n"
+      ;;
+    "CONTAINERID")
+      fct_extract_from_container_id
+      echo -e "List of PODs including the container ID: ${CONTAINERID}\n"
+      ;;
+    "CGROUP")
+      fct_cgroup
+      echo -e "List of PODs including the cgroup: ${CGROUP}\n"
+      ;;
+    "IMAGE")
+      POD_IDS_LIST=($(awk -v imageid=${IMAGEID} -v position=${PODID_POSITION} '{if($(2) == imageid){print $(NF-position)}}' ${CRIO_PATH}/crictl_ps_-a 2>/dev/null | sort -u | awk '{printf "%s ",$0}'))
+      echo -e "List of PODs including the image ID: ${IMAGEID}\n"
+      ;;
+    "NAMESPACE")
+      POD_IDS_LIST=($(awk -v pod_namespace=${NAMESPACE} '{if($(NF-2) == pod_namespace){printf "%s ",$1}}' ${CRIO_PATH}/crictl_pods 2>/dev/null))
+      echo -e "List of PODs from the namespce: ${NAMESPACE}\n"
+      ;;
+    "STATISTIC")
+      if [[ -f ${CRIO_PATH}/crictl_stats ]] && [[ -z $(grep "level=fatal msg=" ${CRIO_PATH}/crictl_stats 2>/dev/null) ]]
       then
-        POD_LIST=($(awk '{if(($1 != "POD") && ($1 !~ "^time=")){printf "%s,%s,%s,%s\n",$1,$(NF-3),$(NF-2),$(NF-4)}}' ${CRIO_PATH}/crictl_pods 2>/dev/null | sort -r -k 4 -k3 -t',' | awk -F',' -v pod_ids="$(echo "${POD_IDS_LIST[@]}")" 'BEGIN{split(pod_ids,pod_array," ")}{for(ID in pod_array){if($1 == pod_array[ID]){printf "%s ",$0}}}'))
-        fct_pod_list_menu
+        POD_DETAILS=$(grep -Ev "^POD" ${CRIO_PATH}/crictl_pods)
+        CONTAINER_DETAILS=$(awk '{if($1 != "CONTAINER"){print}}' ${CRIO_PATH}/crictl_ps_-a 2>/dev/null | sed -e "s/About \([a-z]*\) \([a-z]*\) ago/About_\1_\2_ago/" -e "s/\([0-9]*\) \([a-z]*\) ago/\1_\2_ago/")
+        if [[ $(head -1 ${CRIO_PATH}/crictl_ps_-a | awk '{print $NF}') == "POD" ]]
+        then
+          CONTAINER_IDS=($(echo "${CONTAINER_DETAILS}" |awk '{printf "%s|%s|%s|%s|%s|%s|%s ",$7,$8,$1,$5,$4,$3,$6}'))
+        else
+          CONTAINER_IDS=($(echo "${CONTAINER_DETAILS}" |awk '{printf "%s|%s|%s|%s|%s|%s|%s ",$7,"-",$1,$5,$4,$3,$6}'))
+        fi
+      else
+        if [[ ! -f ${CRIO_PATH}/crictl_stats ]]
+        then
+          echo -e "${redtext}ERR: Unable to find the stats file: ${CRIO_PATH}/crictl_stats\n${resetcolor}\n" && fct_help && exit 7
+        else
+          echo -e "${redtext}ERR: Fatal error detected in the stats file: ${CRIO_PATH}/crictl_stats\n${resetcolor}\n" && fct_help && exit 8
+        fi
       fi
-    fi
-  fi
-fi
-
-# Check the type of crictl_stats files
-if [[ -f ${CRIO_PATH}/crictl_stats ]] && [[ -z $(grep "level=fatal msg=" ${CRIO_PATH}/crictl_stats 2>/dev/null) ]]
-then
-  if [[ $(awk 'BEGIN{namepresence="false"}{if($2 == "NAME"){namepresence="true"}}END{print namepresence}' ${CRIO_PATH}/crictl_stats) == "true" ]]
-  then
-    CRICTL_STATS_TYPE=name
-  else
-    CRICTL_STATS_TYPE=other
-  fi
-else
-  CRICTL_STATS_TYPE=none
+      ;;
+    "OVERLAY")
+      if [[ ! -d ${PODPATH} ]]
+      then
+        echo -e "${redtext}ERR: The <$PODPATH> does not exist and is required for this option\nPlease check the content of the sosreport${resetcolor}\n" && fct_help && exit 9
+      fi
+      POD_IDS_LIST=($(jq -r --arg overlay "${OVERLAY}" '.? | select(.info.runtimeSpec.root.path | test($overlay)) | "\(.status.id[0:13]) "' $(file ${PODPATH}/crictl_inspectp_* | grep -E "JSON data" | cut -d':' -f1) 2>/dev/null))
+      if [[ -z ${POD_IDS_LIST} ]]
+      then
+        CONTAINERID=$(jq -r --arg overlay "$(echo ${OVERLAY} | sed -e "s/crio-//")" '.? | select(.info.runtimeSpec.root.path | test($overlay)) | "\(.status.id[0:13])"' $(file ${CONTAINERPATH}/crictl_inspect* | grep -E "JSON data" | cut -d':' -f1) 2>/dev/null)
+        fct_extract_from_container_id
+      fi
+      echo -e "List of PODs including the overlay: ${OVERLAY}\n"
+      ;;
+    "PROCPID")
+      fct_check_proc_files
+      WARN=$?
+      if [[ ${WARN} == 0 ]]
+      then
+        CGROUP="$(awk -v  procid=${PROC_PID} '{if($1 == procid){print}}' ${PS_GROUP} 2>/dev/null | sed -e "s/.*crio-[a-z-]*\([0-9a-zA-Z_]*\).scope.*/\1/")"
+        if [[ ! -z ${CGROUP} ]]
+        then
+          fct_cgroup
+        fi
+      else
+        echo -e "${redtext}ERR: Unable to retrieve the Process ID details as the process files are missing.${resetcolor}\n"
+      fi
+      echo -e "List of PODs including the PROC_PID: ${PROC_PID}\n"
+      ;;
+    "PODUID")
+      if [[ ! -d ${PODPATH} ]]
+      then
+        echo -e "${redtext}ERR: The <$PODPATH> does not exist and is required for this option\nPlease check the content of the sosreport${resetcolor}\n" && fct_help && exit 9
+      fi
+      POD_IDS_LIST=($(jq -r --arg poduid "${PODUID}" '.? | select(.status.metadata.uid == $poduid) | "\(.status.id[0:13]) "' $(file ${PODPATH}/crictl_inspectp_* | grep -E "JSON data" | cut -d':' -f1) 2>/dev/null))
+      echo -e "List of PODs including the POD_UID: ${PODUID}\n"
+      ;;
+  esac
 fi
 
 if [[ ${PODFILTER} == "STATISTIC" ]]
@@ -742,27 +767,31 @@ then
     echo "$(echo ${CONTAINER_IDS[${NUM}]} | cut -d',' -f1)|$(fct_container_statistic ${CONTAINER_ID})" | sed -e "s/About_\([a-z]*\)_\([a-z]*\)_ago/About \1 \2 ago/" -e "s/\([0-9]*\)_\([a-z]*\)_ago/\1 \2 ago/"
     NUM=$[NUM+1]
   done | sort -${SORTFILTER}r -t'|' -k${SORT_VALUE})
-  SUM_STATS=$(awk 'BEGIN{sum_cpu=0;sum_mem=0;sum_disk=0;sum_inode=0} {sum_cpu+=$3;mem_value=substr($4,1,length($4)-1);mem_unit=substr($4,length($4)-1);if(mem_unit=="GB"){sum_mem+=(mem_value * 1024)} else if(mem_unit=="TB"){sum_mem+=(mem_value * 1024 * 1024)} else if((mem_unit=="kB")||(mem_unit=="KB")){sum_mem+=(mem_value / 1024)} else {sum_mem+=mem_value};disk_value=substr($5,1,length($5)-1);disk_unit=substr($5,length($5)-1);if(disk_unit=="GB"){sum_disk+=(disk_value * 1024)} else if(disk_unit=="TB"){sum_disk+=(disk_value * 1024 * 1024)} else if((disk_unit=="kB") || (disk_unit=="KB")){sum_disk+=(disk_value / 1024)} else {sum_disk+=disk_value};sum_inode+=$NF} END{print sum_cpu"|"sum_mem" MB|"sum_disk" MB|"sum_inode}' ${CRIO_PATH}/crictl_stats)
+  SUM_STATS=$(awk 'BEGIN{sum_cpu=0;sum_mem=0;sum_disk=0;sum_inode=0} {sum_cpu+=$3;mem_value=substr($4,1,length($4)-1);mem_unit=substr($4,length($4)-1);if(mem_unit=="GB"){sum_mem+=(mem_value * 1024)} else if(mem_unit=="TB"){sum_mem+=(mem_value * 1024 * 1024)} else if((mem_unit=="kB")||(mem_unit=="KB")){sum_mem+=(mem_value / 1024)} else {sum_mem+=mem_value};disk_value=substr($5,1,length($5)-2);disk_unit=substr($5,length($5)-1);if(disk_unit=="GB"){sum_disk+=(disk_value * 1024)} else if(disk_unit=="TB"){sum_disk+=(disk_value * 1024 * 1024)} else if((disk_unit=="kB") || (disk_unit=="KB")){sum_disk+=(disk_value / 1024)} else {sum_disk+=disk_value};sum_inode+=$NF} END{print sum_cpu"|"sum_mem" MB|"sum_disk" MB|"sum_inode}' ${CRIO_PATH}/crictl_stats)
   echo -e " | | | | | |TOTAL|${SUM_STATS}\n | | | | | |-------|-------------|---------|----------|------|\nPOD ID|POD NAME|CONTAINER ID|CONTAINER NAME|STATE|CREATED|ATTEMPT|CPU USAGE (%)|MEM USAGE|DISK USAGE|INODES|\n------|---------|------------|--------------|-----|-------|-------|-------------|---------|----------|------|\n${CONTAINERS_STAT_LIST}" | column -t -s'|'
 else
+  if [[ ${#POD_IDS_LIST[@]} == 1 ]]
+  then
+    PODID=${POD_IDS_LIST[0]}
+  else
+    if [[ ${#POD_IDS_LIST[@]} -ge 2 ]]
+    then
+      POD_LIST=($(awk '{if(($1 != "POD") && ($1 !~ "^time=")){printf "%s,%s,%s,%s\n",$1,$(NF-3),$(NF-2),$(NF-4)}}' ${CRIO_PATH}/crictl_pods 2>/dev/null | sort -r -k 4 -k3 -t',' | awk -F',' -v pod_ids="$(echo "${POD_IDS_LIST[@]}")" 'BEGIN{split(pod_ids,pod_array," ")}{for(ID in pod_array){if($1 == pod_array[ID]){printf "%s ",$0}}}'))
+      fct_pod_list_menu
+    fi
+  fi
   # Trunking the PODID to 13 characters
   PODID=$(echo ${PODID}  | cut -c1-13)
 
   # Collect the POD Details & set the missing value
   POD_HEADER=$(awk '($1 == "POD"){print}' ${CRIO_PATH}/crictl_pods 2>/dev/null | sed -e "s/POD ID/POD_ID/")
-  POD_DETAILS=${POD_DETAILS:-$(awk -v podid=${PODID} -v podname=${PODNAME} '{if(($1 == podid) || ($(NF-3) == podname)){print} }' ${CRIO_PATH}/crictl_pods 2>/dev/null | sed -e "s/About \([a-z]*\) \([a-z]*\) ago/About_\1_\2_ago/" -e "s/\([0-9]*\) \([a-z]*\) ago/\1_\2_ago/")}
+  POD_DETAILS=${POD_DETAILS:-$(awk -v podid=${PODID} '{if(($1 == podid) || ($(NF-3) == podname)){print} }' ${CRIO_PATH}/crictl_pods 2>/dev/null | sed -e "s/About \([a-z]*\) \([a-z]*\) ago/About_\1_\2_ago/" -e "s/\([0-9]*\) \([a-z]*\) ago/\1_\2_ago/")}
   if [[ -z "${POD_DETAILS}" ]]
   then
     echo -e "Unable to find a POD from the specified parameter\n" && fct_help && exit 10
   fi
-  if [[ ${PODID} == "null" ]]
-  then
-    PODID=$(echo "${POD_DETAILS}" | awk '{print $1}')
-  fi
-  if [[ ${PODNAME} == "null" ]]
-  then
-    PODNAME=$(echo "${POD_DETAILS}" | awk '{print $(NF-3)}')
-  fi
+  PODID=$(echo "${POD_DETAILS}" | awk '{print $1}')
+  PODNAME=$(echo "${POD_DETAILS}" | awk '{print $(NF-3)}')
   # Collect the Container(s) details and create an Array with the IDs
   fct_container_details
   # Create the List of option  for the Menu


### PR DESCRIPTION
- Including the container space usage in the '-D' option from the crictl_stats, when available.
- Script optimization to significally reduce the time to collect data and display layers.
- Add an extra end-of-line for the 'INFO','WARN', 'ERR' messages to avoid any confusion, when multiple are triggered.
- Fixing a typo in the 'Readme' where the uninstall commands are using the wrong alias.
- Fixing a bug when the 'PODID' was not set properly when multiple POD Name were matching in the 'crictl_pods' file.
- Fixing a typo where the 'PODPATH' was not set correctly when missing.